### PR TITLE
Enhance metadata extraction for IFC uploads

### DIFF
--- a/ifc_reuse/core/models.py
+++ b/ifc_reuse/core/models.py
@@ -12,6 +12,8 @@ class ReusableComponent(models.Model):
 class UploadedIFC(models.Model):
     name = models.CharField(max_length=256)
     file = models.FileField(upload_to='ifc_files/')
+    project_name = models.CharField(max_length=256, blank=True)
+    location = models.CharField(max_length=256, blank=True)
     uploaded_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):

--- a/ifc_reuse/core/utils.py
+++ b/ifc_reuse/core/utils.py
@@ -1,0 +1,28 @@
+import ifcopenshell
+from typing import Optional, Tuple
+
+
+def get_type_and_material(ifc_path: str, express_id: int) -> Tuple[str, str]:
+    """Return the IFC entity type name and material for an element."""
+    try:
+        model = ifcopenshell.open(ifc_path)
+    except Exception:
+        return "Unknown", "Unknown"
+
+    try:
+        element = model.by_id(express_id)
+        if not element:
+            return "Unknown", "Unknown"
+        element_type = element.is_a()
+
+        material_name = "Unknown"
+        for rel in model.by_type("IfcRelAssociatesMaterial"):
+            if element.id() in [obj.id() for obj in rel.RelatedObjects]:
+                mat = rel.RelatingMaterial
+                # The relating material can be IfcMaterial or another entity
+                if hasattr(mat, "Name"):
+                    material_name = mat.Name
+                break
+        return element_type or "Unknown", material_name
+    except Exception:
+        return "Unknown", "Unknown"


### PR DESCRIPTION
## Summary
- store project name and location for uploaded IFCs
- provide utility to extract element type and material with ifcopenshell
- enrich saved fragment metadata with type, material and location

## Testing
- `python -m py_compile core/models.py core/views.py core/utils.py`
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6848366d0c54832eb019431f36ccb1df