### PR TITLE
Fix user profile signals

### DIFF
--- a/ifc_reuse/accounts/signals.py
+++ b/ifc_reuse/accounts/signals.py
@@ -7,6 +7,7 @@ from .models import Profile
 def create_user_profile(sender, instance, created, **kwargs):
     if created:
         Profile.objects.create(user=instance)
-def create_user_profile(sender, instance, created, **kwargs):
-    if created:
-        Profile.objects.create(user=instance)
+
+@receiver(post_save, sender=User)
+def save_user_profile(sender, instance, **kwargs):
+    instance.profile.save()

--- a/ifc_reuse/accounts/views.py
+++ b/ifc_reuse/accounts/views.py
@@ -3,6 +3,8 @@ from django.contrib.auth import authenticate, login, logout
 from django.contrib import messages
 from .forms import UserRegistrationForm
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
+from django.db import IntegrityError
 
 def register(request):
     if request.method == 'POST':

--- a/ifc_reuse/ifc_reuse/settings.py
+++ b/ifc_reuse/ifc_reuse/settings.py
@@ -104,4 +104,3 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ifc_reuse_django.settings')


### PR DESCRIPTION
## Summary
- fix duplicate signal functions and add save handler
- add missing imports in `accounts.views`
- remove wrong environment variable from settings

## Testing
- `python -m py_compile accounts/views.py accounts/signals.py ifc_reuse/settings.py`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68483508e7c8832ea3d0e48cdc0b8d18