### PR TITLE
Fix viewer redirect to use numeric model ID

### DIFF
--- a/ifc_reuse/core/templates/reuse/upload.html
+++ b/ifc_reuse/core/templates/reuse/upload.html
@@ -175,9 +175,7 @@
                 const result = await response.json();
                 if (response.ok && result.status === 'uploaded') {
                     statusDiv.textContent = 'Upload successful! Redirecting to viewer...';
-                    const fileUrl = result.file_url;
-                    const fileId = result.file_url.split('/').pop();
-                    window.location.href = `/viewer/${fileId}/`;
+                    window.location.href = `/viewer/${result.id}/`;
                 } else {
                     statusDiv.textContent = `Error: ${result.error || 'Upload failed'}`;
                 }

--- a/ifc_reuse/core/views.py
+++ b/ifc_reuse/core/views.py
@@ -92,6 +92,7 @@ def list_uploaded_ifcs(request):
     files = UploadedIFC.objects.all().order_by('-uploaded_at')
     data = [
         {
+            'id': file.id,
             'name': file.name,
             'url': file.file.url,
             'project_name': file.project_name,
@@ -190,4 +191,8 @@ def upload_ifc_file(request):
         location=location,
     )
 
-    return JsonResponse({'status': 'uploaded', 'file_url': instance.file.url})
+    return JsonResponse({
+        'status': 'uploaded',
+        'file_url': instance.file.url,
+        'id': instance.id,
+    })

--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -192,15 +192,15 @@ async function initializeIfcComponents() {
 async function loadIfc() {
     console.log('⏳ Loading IFC...');
     try {
-        const modelId = window.location.pathname.split('/').pop();
+        const modelId = window.location.pathname.split('/').filter(Boolean).pop();
         console.log('🧪 Fetching IFC file for model_id:', modelId);
 
-        const response = await fetch('/api/ifc-files/');
+        const response = await fetch('/list-ifcs/');
         if (!response.ok) throw new Error(`HTTP error ${response.status}: ${response.statusText}`);
         const files = await response.json();
         console.log('🧪 API response:', files);
 
-        const file = files.find(f => f.url.includes(modelId));
+        const file = files.find(f => String(f.id) === String(modelId));
         if (!file) throw new Error(`No IFC file found for model_id: ${modelId}`);
         console.log('🧪 Found IFC file:', file.url);
 


### PR DESCRIPTION
## Summary
- return the newly created `UploadedIFC` object's ID from the upload API
- include file IDs in the `list-ifcs` API
- redirect to `/viewer/<id>/` after upload
- look up IFC files by numeric ID in the viewer script

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68483c171e80832e96ebdc5806a694cb