### PR TITLE
Enhance IFC metadata extraction

### DIFF
--- a/ifc_reuse/core/utils.py
+++ b/ifc_reuse/core/utils.py
@@ -1,28 +1,75 @@
 import ifcopenshell
-from typing import Optional, Tuple
+from typing import Dict, List, Optional
 
 
-def get_type_and_material(ifc_path: str, express_id: int) -> Tuple[str, str]:
-    """Return the IFC entity type name and material for an element."""
+def get_element_info(ifc_path: str, express_id: int) -> Dict[str, object]:
+    """Return basic IFC metadata for the given element."""
+
+    info: Dict[str, object] = {"type": "Unknown", "materials": []}
     try:
         model = ifcopenshell.open(ifc_path)
     except Exception:
-        return "Unknown", "Unknown"
+        return info
 
+    element = model.by_id(express_id)
+    if not element:
+        return info
+
+    # Entity type name
+    info["type"] = element.is_a() or "Unknown"
+
+    # PredefinedType if available (e.g. for walls, doors, windows)
+    predefined = getattr(element, "PredefinedType", None)
+    if predefined and predefined != "NOTDEFINED":
+        info["predefinedType"] = str(predefined)
+
+    # Associated materials and optional layer thickness
+    materials: List[Dict[str, object]] = []
     try:
-        element = model.by_id(express_id)
-        if not element:
-            return "Unknown", "Unknown"
-        element_type = element.is_a()
-
-        material_name = "Unknown"
         for rel in model.by_type("IfcRelAssociatesMaterial"):
             if element.id() in [obj.id() for obj in rel.RelatedObjects]:
                 mat = rel.RelatingMaterial
-                # The relating material can be IfcMaterial or another entity
-                if hasattr(mat, "Name"):
-                    material_name = mat.Name
+
+                def add_material(mat_obj, thickness: Optional[float] = None):
+                    name = getattr(mat_obj, "Name", None)
+                    entry: Dict[str, object] = {}
+                    if name:
+                        entry["name"] = name
+                    if thickness is not None:
+                        entry["thickness"] = thickness
+                    if entry:
+                        materials.append(entry)
+
+                if mat.is_a("IfcMaterialLayerSetUsage"):
+                    for layer in mat.ForLayerSet.MaterialLayers:
+                        add_material(layer.Material, getattr(layer, "LayerThickness", None))
+                elif mat.is_a("IfcMaterialLayerSet"):
+                    for layer in mat.MaterialLayers:
+                        add_material(layer.Material, getattr(layer, "LayerThickness", None))
+                elif mat.is_a("IfcMaterial"):
+                    add_material(mat)
+                elif hasattr(mat, "Name"):
+                    add_material(mat)
+
                 break
-        return element_type or "Unknown", material_name
     except Exception:
-        return "Unknown", "Unknown"
+        pass
+
+    if materials:
+        info["materials"] = materials
+        # Keep backward compatibility with single material
+        info["material"] = materials[0].get("name", "Unknown")
+
+    # Determine containing building storey if any
+    try:
+        for rel in model.by_type("IfcRelContainedInSpatialStructure"):
+            if element.id() in [obj.id() for obj in rel.RelatedElements]:
+                storey = rel.RelatingStructure
+                if storey and storey.is_a("IfcBuildingStorey"):
+                    info["storey"] = getattr(storey, "Name", None)
+                break
+    except Exception:
+        pass
+
+    return info
+


### PR DESCRIPTION
## Summary
- collect detailed material info and spatial metadata using `get_element_info`
- store predefined type, list of materials, and storey in uploaded metadata

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68485173e914832eb62de4e2072199fe