### PR TITLE
Fix JSON file naming to use GlobalId

### DIFF
--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -463,7 +463,11 @@ function setupSelection() {
                 const dirHandle = await window.showDirectoryPicker();
                 console.log('🗂️ Directory selected:', dirHandle.name);
 
-                const nameBase = metadata.GlobalId || `frag_${expressID}`;
+                let globalId = metadata.GlobalId;
+                if (globalId && typeof globalId === 'object') {
+                    globalId = globalId.value || globalId.id || globalId.GlobalId || globalId.toString();
+                }
+                const nameBase = globalId || `frag_${expressID}`;
                 const jsonFileHandle = await dirHandle.getFileHandle(`${nameBase}.json`, { create: true });
                 const jsonWritable = await jsonFileHandle.createWritable();
                 await jsonWritable.write(JSON.stringify(metadata, null, 2));


### PR DESCRIPTION
## Summary
- ensure metadata GlobalId value is extracted before naming files

## Testing
- `python ifc_reuse/manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68496367dbcc832e87d2ad5a8b6f2b6f