### PR TITLE
Add clipping plane controls and styles

### DIFF
--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -203,6 +203,7 @@ async function initializeClippingComponents() {
 
         clipper = components.get(Clipper);
         clipper.enabled = true;
+        clipper.visible = true; // show plane helpers
 
         clipEdges = components.get(ClipEdges);
         clipEdges.visible = true;
@@ -236,6 +237,21 @@ async function initializeClippingComponents() {
     }
 }
 
+// Create clipping styles for a given model
+function setupClipStyles(mesh) {
+    if (!clipEdges || !clipEdges.styles) return;
+    const fill = new THREE.MeshBasicMaterial({ color: 'lightblue', side: 2 });
+    const line = new THREE.LineBasicMaterial({ color: 'blue' });
+    const outline = new THREE.MeshBasicMaterial({ color: 'blue', opacity: 0.5, side: 2, transparent: true });
+    const meshes = new Set([mesh]);
+    if (!clipEdges.styles.list['Default']) {
+        clipEdges.styles.create('Default', meshes, world, line, fill, outline);
+    } else {
+        clipEdges.styles.list['Default'].meshes = meshes;
+    }
+    clipEdges.update(true);
+}
+
 // Load IFC model
 async function loadIfc() {
     console.log('⏳ Loading IFC...');
@@ -266,11 +282,7 @@ async function loadIfc() {
         console.log('✅ IFC model loaded:', model);
 
         if (clipEdges && clipEdges.styles) {
-            const fill = new THREE.MeshBasicMaterial({ color: 'lightblue', side: 2 });
-            const line = new THREE.LineBasicMaterial({ color: 'blue' });
-            const outline = new THREE.MeshBasicMaterial({ color: 'blue', opacity: 0.5, side: 2, transparent: true });
-            clipEdges.styles.create('Default', new Set([model]), world, line, fill, outline);
-            clipEdges.update(true);
+            setupClipStyles(model);
         }
 
         modelGroupUUID = model.uuid;


### PR DESCRIPTION
## Summary
- activate clipping plane helpers
- wrap clip style creation in a helper
- call style helper when loading IFC models

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c0e9d7bfc832e9d8676affb084855