### PR TITLE
Handle missing elementProperties in frontend

### DIFF
--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -198,6 +198,10 @@ async function initializeIfcComponents() {
 
 // Initialize element properties table and panel
 function initializePropertiesUI() {
+    if (!BUI.tables?.elementProperties) {
+        console.error('BUI.tables.elementProperties is not available');
+        return;
+    }
     [propertiesTable, updatePropertiesTable] = BUI.tables.elementProperties({
         components,
         fragmentIdMap: {},


### PR DESCRIPTION
## Summary
- guard against missing `BUI.tables.elementProperties` in `frontend/main.js`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684c191afe68832eb9563933cd32b4d2