### PR TITLE
Handle missing BUI properties table

### DIFF
--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -199,7 +199,20 @@ async function initializeIfcComponents() {
 // Initialize element properties table and panel
 function initializePropertiesUI() {
     if (!BUI.tables?.elementProperties) {
-        console.error('BUI.tables.elementProperties is not available');
+        console.warn('BUI.tables.elementProperties is not available. ' +
+            'Falling back to simple property display.');
+
+        propertiesPanel = BUI.Component.create(() => {
+            return BUI.html`
+            <bim-panel label="Properties">
+              <bim-panel-section label="Element Data">
+                <span style="color: var(--bim-ui_text-weak);">
+                  Properties table unavailable.
+                </span>
+              </bim-panel-section>
+            </bim-panel>
+            `;
+        });
         return;
     }
     [propertiesTable, updatePropertiesTable] = BUI.tables.elementProperties({


### PR DESCRIPTION
## Summary
- add a graceful fallback when `BUI.tables.elementProperties` is not available

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684c1a414dc0832e8f82680c41a8474f