### PR TITLE
Fix display of undefined properties

### DIFF
--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -263,7 +263,9 @@ function initializePropertiesUI() {
         } catch (err) {
             console.warn('⚠️ Error fetching element info:', err);
         }
-        allRows = Object.entries(props).map(([property, value]) => ({ property, value }));
+        allRows = Object.entries(props)
+            .filter(([, value]) => value !== undefined && value !== null)
+            .map(([property, value]) => ({ property, value }));
         propertiesTable.data = allRows;
     };
 


### PR DESCRIPTION
## Summary
- filter out undefined/null values before displaying properties

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684c6ab980d8832e83c771ca5697341d