### PR TITLE
Add categories page

### DIFF
--- a/ifc_reuse/core/templates/reuse/catalog.html
+++ b/ifc_reuse/core/templates/reuse/catalog.html
@@ -31,6 +31,7 @@
             <nav class="flex items-center space-x-4 ml-4 text-lg">
                 <a href="{% url 'core:index' %}" class="text-[#F1FAEE] hover:text-[#4CAF50]">Home</a>
                 <a href="{% url 'core:catalog' %}" class="text-[#4CAF50] font-semibold">Katalog</a>
+                <a href="{% url 'core:categories' %}" class="text-[#F1FAEE] hover:text-[#4CAF50]">Kategorien</a>
                 <a href="{% url 'core:upload_page' %}" class="text-[#F1FAEE] hover:text-[#4CAF50]">Upload</a>
                 <a href="{% url 'core:api' %}" class="text-[#F1FAEE] hover:text-[#4CAF50]">API</a>
                 <a href="{% url 'core:about' %}" class="text-[#F1FAEE] hover:text-[#4CAF50]">Über Uns</a>
@@ -140,7 +141,7 @@
             }
         });
         // Fetch components
-        fetch('/api/catalog/')
+        fetch('/reusable-components/')
             .then(response => response.json())
             .then(data => {
                 const catalogContent = document.getElementById('catalog-content');

--- a/ifc_reuse/core/templates/reuse/categories.html
+++ b/ifc_reuse/core/templates/reuse/categories.html
@@ -1,0 +1,51 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="de" class="min-h-screen flex flex-col bg-gray-900 text-[#F1FAEE]">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kategorien - IFC Reuse</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        .dropdown-content {
+            display: none;
+            position: absolute;
+            right: 0;
+            background-color: #2d3748;
+            min-width: 150px;
+            z-index: 10;
+        }
+        .dropdown.active .dropdown-content {
+            display: block;
+        }
+    </style>
+</head>
+<body class="min-h-screen flex flex-col">
+    <!-- Header -->
+    <header class="bg-gray-800 shadow-md py-4 px-6 flex justify-between items-center">
+        <div class="flex items-center space-x-4">
+            <img src="{% static 'images/logo.jpg' %}" alt="Logo" class="h-20 mx-2">
+            <nav class="flex items-center space-x-4 ml-4 text-lg">
+                <a href="{% url 'core:index' %}" class="text-[#F1FAEE] hover:text-[#4CAF50]">Home</a>
+                <a href="{% url 'core:catalog' %}" class="text-[#F1FAEE] hover:text-[#4CAF50]">Katalog</a>
+                <a href="{% url 'core:categories' %}" class="text-[#4CAF50] font-semibold">Kategorien</a>
+            </nav>
+        </div>
+    </header>
+    <main class="container mx-auto px-6 py-12 flex-grow">
+        <h1 class="text-2xl font-bold text-center mb-6">Bauteil-Kategorien</h1>
+        {% if categories %}
+            {% for cat, comps in categories.items %}
+                <h2 class="text-xl font-semibold mt-8">{{ cat }}</h2>
+                <ul class="mt-2">
+                    {% for comp in comps %}
+                        <li class="bg-gray-800 shadow-md rounded-lg p-2 mt-1">{{ comp.name }} ({{ comp.global_id }})</li>
+                    {% endfor %}
+                </ul>
+            {% endfor %}
+        {% else %}
+            <p class="text-center text-gray-400">Keine Komponenten gefunden.</p>
+        {% endif %}
+    </main>
+</body>
+</html>

--- a/ifc_reuse/core/urls.py
+++ b/ifc_reuse/core/urls.py
@@ -6,6 +6,7 @@ app_name = 'core'
 urlpatterns = [
     path('', views.index, name='index'),
     path('catalog/', views.catalog, name='catalog'),
+    path('categories/', views.categories, name='categories'),
     path('upload/', views.upload_page, name='upload_page'),
     path('api/', views.api_view, name='api'),
     path('viewer/<int:model_id>/', views.viewer_page, name='viewer_page'),

--- a/ifc_reuse/core/views.py
+++ b/ifc_reuse/core/views.py
@@ -24,6 +24,34 @@ def catalog(request):
     return render(request, "reuse/catalog.html")
 
 
+def categories(request):
+    comp_dir = os.path.join(settings.MEDIA_ROOT, "reusable_components")
+    categories = {}
+    if os.path.isdir(comp_dir):
+        for fname in os.listdir(comp_dir):
+            if not fname.endswith(".json"):
+                continue
+            path = os.path.join(comp_dir, fname)
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+            except Exception:
+                continue
+
+            cat = data.get("type", "Unknown")
+            name = data.get("Name")
+            if isinstance(name, dict):
+                name = name.get("value")
+            gid = data.get("GlobalId")
+            if isinstance(gid, dict):
+                gid = gid.get("value")
+
+            info = {"name": name or "Unnamed", "global_id": gid or ""}
+            categories.setdefault(cat, []).append(info)
+
+    return render(request, "reuse/categories.html", {"categories": categories})
+
+
 def upload_page(request):
     return render(request, 'reuse/upload.html')
 

--- a/ifc_reuse/frontend/catalog.js
+++ b/ifc_reuse/frontend/catalog.js
@@ -1,6 +1,6 @@
 const container = document.getElementById('catalog-container');
 
-fetch('http://localhost:8000/api/catalog/')
+fetch('/reusable-components/')
   .then(response => response.json())
   .then(data => {
     data.forEach(component => {


### PR DESCRIPTION
## Summary
- implement a `categories` view that reads JSON metadata files
- add new `categories` URL and page template
- update catalog page and JS to use `/reusable-components/` endpoint

## Testing
- `python3 ifc_reuse/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685016f47ccc832eb24d1738a97a0bc7