### PR TITLE
Fix categories API

### DIFF
--- a/ifc_reuse/core/urls.py
+++ b/ifc_reuse/core/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path('upload-fragment/', views.upload_fragment, name='upload_fragment'),
     path('mark-component/', views.mark_component, name='mark_component'),
     path('reusable-components/', views.reusable_components, name='reusable_components'),
+    path('api/catalog/', views.catalog_api, name='catalog_api'),
     path('get-element-info/', views.get_element_info_view, name='get_element_info'),
     path('upload-ifc/', views.upload_ifc_file, name='upload_ifc'),
 ]

--- a/ifc_reuse/core/views.py
+++ b/ifc_reuse/core/views.py
@@ -52,6 +52,20 @@ def categories(request):
     return render(request, "reuse/categories.html", {"categories": categories})
 
 
+def catalog_api(request):
+    """Return components grouped by type as JSON."""
+    components = ReusableComponent.objects.all().values('type', 'name', 'global_id')
+    categories = {}
+    for comp in components:
+        cat = comp['type'] or 'Unknown'
+        info = {
+            'name': comp['name'],
+            'global_id': comp['global_id'],
+        }
+        categories.setdefault(cat, []).append(info)
+    return JsonResponse(categories)
+
+
 def upload_page(request):
     return render(request, 'reuse/upload.html')
 


### PR DESCRIPTION
## Summary
- add new `catalog_api` view returning JSON of reusable components
- expose catalog API route

## Testing
- `python ifc_reuse/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685018b7cec0832ea7d2e9474e730831