### PR TITLE
Persist components on fragment upload

### DIFF
--- a/ifc_reuse/core/models.py
+++ b/ifc_reuse/core/models.py
@@ -19,4 +19,4 @@ class ReusableComponent(models.Model):
     uploaded_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
-        return self.name
+        return f"{self.component_type} ({self.ifc_file.name})"

--- a/ifc_reuse/core/views.py
+++ b/ifc_reuse/core/views.py
@@ -234,6 +234,20 @@ def upload_fragment(request):
             os.path.join(base_path, json_file.name),
             ContentFile(json_content.encode("utf-8"))
         )
+
+        try:
+            upload = UploadedIFC.objects.get(file__contains=ifc_filename) if ifc_filename else None
+        except UploadedIFC.DoesNotExist:
+            upload = None
+
+        ReusableComponent.objects.create(
+            ifc_file=upload,
+            component_type=metadata.get("Type", "Unknown"),
+            storey=metadata.get("Storey"),
+            material_name=metadata.get("Material"),
+            json_file_path=json_path,
+        )
+
         return JsonResponse({
             "status": "ok",
             "fragment_url": default_storage.url(frag_path),


### PR DESCRIPTION
## Summary
- ensure `__str__` for `ReusableComponent` returns useful data
- automatically create a `ReusableComponent` entry during fragment upload

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68505eff346c832e8bdded6e2f04fed9