### PR TITLE
Add backend upload on save

### DIFF
--- a/ifc_reuse/core/utils.py
+++ b/ifc_reuse/core/utils.py
@@ -138,13 +138,14 @@ def save_metadata_and_create_component(metadata: Dict[str, object], filename: st
     except UploadedIFC.MultipleObjectsReturned:
         upload = UploadedIFC.objects.filter(file__contains=model_uuid).first()
 
-    # 5. Create ReusableComponent entry
-    ReusableComponent.objects.create(
-        ifc_file=upload,
-        component_type=info.get("type", "Unknown"),
-        storey=info.get("storey"),
-        material_name=info.get("material"),
-        json_file_path=json_path,
-    )
+    # 5. Create ReusableComponent entry only if we found the IFC upload
+    if upload:
+        ReusableComponent.objects.create(
+            ifc_file=upload,
+            component_type=info.get("type", "Unknown"),
+            storey=info.get("storey"),
+            material_name=info.get("material"),
+            json_file_path=json_path,
+        )
 
     return json_path

--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -706,6 +706,15 @@ function setupSelection() {
                         `${nameBase}.json`
                     );
 
+                    const uploadResp = await fetch('/upload-fragment/', {
+                        method: 'POST',
+                        body: formData,
+                    });
+                    if (uploadResp.ok) {
+                        console.log('✅ Component uploaded');
+                    } else {
+                        console.error('❌ Failed to upload component:', uploadResp.statusText);
+                    }
 
                 } catch (err) {
                     console.error('❌ Failed to upload component:', err);


### PR DESCRIPTION
## Summary
- send POST request to `/upload-fragment/` after writing metadata JSON
- avoid creating database entry if the IFC model is missing

## Testing
- `python ifc_reuse/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68509da4962c832e85e6c1151de68162