### PR TITLE
Implement metadata save endpoint

### DIFF
--- a/ifc_reuse/core/urls.py
+++ b/ifc_reuse/core/urls.py
@@ -18,5 +18,6 @@ urlpatterns = [
     path('reusable-components/', views.reusable_components, name='reusable_components'),
     path('api/catalog/', views.catalog_api, name='catalog_api'),
     path('get-element-info/', views.get_element_info_view, name='get_element_info'),
+    path('save-component-metadata/', views.save_component_metadata, name='save_component_metadata'),
 
 ]

--- a/ifc_reuse/core/views.py
+++ b/ifc_reuse/core/views.py
@@ -208,4 +208,24 @@ def reusable_components(request):
     return JsonResponse(list(components), safe=False)
 
 
+@require_http_methods(["POST"])
+def save_component_metadata(request):
+    """Save metadata JSON and create a ``ReusableComponent`` entry."""
+
+    try:
+        payload = json.loads(request.body.decode("utf-8"))
+    except Exception:
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    metadata = payload.get("metadata")
+    filename = payload.get("filename")
+
+    if not isinstance(metadata, dict) or not filename:
+        return JsonResponse({"error": "metadata and filename required"}, status=400)
+
+    path = save_metadata_and_create_component(metadata, filename)
+
+    return JsonResponse({"path": path})
+
+
 

--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -692,22 +692,16 @@ function setupSelection() {
                 console.log('📤 Sending json_file_path to backend:', jsonFilePath);
 
                 try {
-                    const formData = new FormData();
-                    if (fragData) {
-                        formData.append(
-                            'fragment',
-                            new Blob([fragData]),
-                            `${nameBase}.frag`
-                        );
+                    const response = await fetch('/save-component-metadata/', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ metadata, filename: `${nameBase}.json` })
+                    });
+                    if (!response.ok) {
+                        throw new Error(`HTTP ${response.status}`);
                     }
-                    formData.append(
-                        'metadata',
-                        new Blob([JSON.stringify(metadata, null, 2)], { type: 'application/json' }),
-                        `${nameBase}.json`
-                    );
-
-
-
+                    const data = await response.json();
+                    console.log('✅ Metadata stored on server:', data.path);
                 } catch (err) {
                     console.error('❌ Failed to upload component:', err);
                 }


### PR DESCRIPTION
## Summary
- call backend to save component metadata in `main.js`
- add `save_component_metadata` API in Django backend

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850a0a93f04832e8e3c39ddd64ed7bf