### PR TITLE
Fix IFC file upload

### DIFF
--- a/ifc_reuse/core/urls.py
+++ b/ifc_reuse/core/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('catalog/', views.categories, name='catalog'),
     path('upload/', views.upload_page, name='upload_page'),
     path('upload-ifc/', views.upload_ifc, name='upload_ifc'),
+    path('viewer/<int:model_id>/', views.viewer_page, name='viewer_page'),
 
     path('about/', views.about, name='about'),
     path('settings/', views.account_settings, name='settings'),

--- a/ifc_reuse/core/views.py
+++ b/ifc_reuse/core/views.py
@@ -283,8 +283,29 @@ def reusable_components(request):
 
 @require_POST
 def upload_ifc(request):
-    # Your logic for handling file upload
-    return JsonResponse({"message": "Upload received"})
+    """Handle IFC file upload and create an :class:`UploadedIFC` entry."""
+
+    file = request.FILES.get("file")
+    if not file:
+        return JsonResponse({"error": "No file provided"}, status=400)
+
+    project_name = request.POST.get("project_name", "")
+    location = request.POST.get("location", "")
+
+    upload = UploadedIFC.objects.create(
+        name=file.name,
+        file=file,
+        project_name=project_name,
+        location=location,
+    )
+
+    return JsonResponse(
+        {
+            "status": "uploaded",
+            "file_url": upload.file.url,
+            "id": upload.id,
+        }
+    )
 
 
 


### PR DESCRIPTION
## Summary
- implement IFC upload endpoint
- restore `/viewer/<model_id>/` URL

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68513e8e8814832e893fb9c4d1ebaaa7