### PR TITLE
Add fragment viewer for catalog items

### DIFF
--- a/ifc_reuse/core/templates/reuse/catalog.html
+++ b/ifc_reuse/core/templates/reuse/catalog.html
@@ -384,7 +384,7 @@
                 <button class="close-button" onclick="closeDetailsPanel()">×</button>
             </div>
             <div class="content">
-                <div class="image-placeholder">Vorschau nicht verfügbar</div>
+                <div id="viewer-container" style="width:100%;height:300px;background:#2d3748;"></div>
                 <div class="property">
                     <strong>Typ:</strong> <span id="element-type" class="na">N/A</span>
                 </div>
@@ -471,6 +471,65 @@
         const commentsUrlBase = "{% url 'core:get_comments' %}";
         const addCommentUrl = "{% url 'core:add_comment' %}";
         const toggleFavoriteUrl = "{% url 'core:toggle_favorite' %}";
+
+        // === Fragment viewer setup ===
+        let viewerComponents = null;
+        let viewerWorld = null;
+        let viewerFragments = null;
+        let viewerModel = null;
+
+        async function initFragmentViewer() {
+            const container = document.getElementById('viewer-container');
+            if (!container) return;
+
+            const libs = await import("{% static 'js/libs/index.mjs' %}");
+            const { Components, Worlds, SimpleScene, SimpleCamera, SimpleRenderer, FragmentsManager } = libs;
+
+            viewerComponents = new Components();
+            await viewerComponents.init();
+
+            const worlds = viewerComponents.get(Worlds);
+            viewerWorld = worlds.create(SimpleScene, SimpleCamera, SimpleRenderer);
+
+            viewerWorld.scene = new SimpleScene(viewerComponents);
+            viewerWorld.renderer = new SimpleRenderer(viewerComponents, container);
+            viewerWorld.camera = new SimpleCamera(viewerComponents);
+
+            viewerWorld.scene.setup();
+            viewerWorld.camera.controls.setLookAt(12, 6, 8, 0, 0, 0);
+
+            viewerFragments = viewerComponents.get(FragmentsManager);
+
+            const animate = () => {
+                requestAnimationFrame(animate);
+                if (viewerWorld?.renderer?.three) {
+                    viewerWorld.renderer.three.render(viewerWorld.scene.three, viewerWorld.camera.three);
+                }
+            };
+            animate();
+        }
+
+        async function loadFragmentFile(url) {
+            if (!viewerFragments) return;
+            const resp = await fetch(url);
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            const buffer = new Uint8Array(await resp.arrayBuffer());
+
+            if (viewerModel) {
+                viewerFragments.disposeGroup(viewerModel.uuid);
+                viewerWorld.scene.three.remove(viewerModel);
+            }
+
+            viewerModel = await viewerFragments.load(buffer);
+            viewerWorld.scene.three.add(viewerModel);
+
+            const box = new THREE.Box3().setFromObject(viewerModel);
+            if (!box.isEmpty()) {
+                viewerWorld.camera.controls.fitToBox(box, true);
+            }
+        }
+
+        initFragmentViewer();
 
         window.adjustPanelPosition = function() {
             const header = document.querySelector('header');
@@ -730,6 +789,13 @@
                     }
 
                     await loadComments(globalId);
+
+                    const fragPath = `/media/reusable_components/${globalId}.frag`;
+                    try {
+                        await loadFragmentFile(fragPath);
+                    } catch (err) {
+                        console.error('Error loading fragment file:', err);
+                    }
 
                     const commentSubmit = document.getElementById('comment-submit');
                     commentSubmit.onclick = () => submitComment(globalId);


### PR DESCRIPTION
## Summary
- show a new 3D viewer inside the catalog details panel
- initialize ThatOpen Components to display `.frag` files
- load the fragment for a selected component

## Testing
- `python ifc_reuse/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68555306b5c8832e9473f051dd1fb9ab