### PR TITLE
Enable .frag export with IfcImporter

### DIFF
--- a/ifc_reuse/frontend/fragment-viewer.js
+++ b/ifc_reuse/frontend/fragment-viewer.js
@@ -21,7 +21,7 @@ components.init();
 world.scene.setup();
 world.camera.controls.setLookAt(12, 6, 8, 0, 0, -10);
 
-const fragmentIfcLoader = components.get(OBC.IfcLoader);
+const fragmentIfcLoader = components.get(OBC.IfcImporter);
 await fragmentIfcLoader.setup();  // Loads WASM via unpkg
 
 // Optional: exclude categories to speed up

--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -149,11 +149,11 @@ async function initializeIfcComponents() {
             throw new Error('Components not initialized');
         }
 
-        const { IfcLoader, FragmentsManager, IfcPropertiesManager } = await import('@thatopen/components');
+        const { IfcImporter, FragmentsManager, IfcPropertiesManager } = await import('@thatopen/components');
         const { Highlighter, Outliner } = await import('@thatopen/components-front');
         const WEBIFC = await import('web-ifc');
 
-        fragmentIfcLoader = components.get(IfcLoader);
+        fragmentIfcLoader = components.get(IfcImporter);
         await fragmentIfcLoader.setup();
         fragmentIfcLoader.settings.webIfc.COORDINATE_TO_ORIGIN = true;
 


### PR DESCRIPTION
## Summary
- switch from deprecated `IfcLoader` to `IfcImporter`
- initialize importer to make `fragments.exportFragments` available

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685557bdfcf0832e89e8bdd612100d02