### PR TITLE
Add client-side fragment export

### DIFF
--- a/ifc_reuse/frontend/fragment-viewer.js
+++ b/ifc_reuse/frontend/fragment-viewer.js
@@ -21,7 +21,7 @@ components.init();
 world.scene.setup();
 world.camera.controls.setLookAt(12, 6, 8, 0, 0, -10);
 
-const fragmentIfcLoader = components.get(OBC.IfcLoader);
+const fragmentIfcLoader = components.get(OBC.FragmentIfcLoader);
 await fragmentIfcLoader.setup();  // Loads WASM via unpkg
 
 // Optional: exclude categories to speed up
@@ -41,7 +41,7 @@ async function loadIfc(url) {
   const file = await fetch(url);
   const data = await file.arrayBuffer();
   const buffer = new Uint8Array(data);
-  const model = await fragmentIfcLoader.load(buffer);
+  const model = await fragmentIfcLoader.load(buffer, "ifc-model");
   model.name = "ifc-model";
   world.scene.three.add(model);
 }
@@ -74,7 +74,7 @@ document.body.append(phoneBtn);
 // Export logic
 function exportFragments() {
   const group = Array.from(fragments.groups.values())[0];
-  const data = fragments.export(group);
+  const data = fragments.exportFragments(group);
   download(new File([new Blob([data])], "model.frag"));
 
   const props = group.getLocalProperties();

--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -149,11 +149,11 @@ async function initializeIfcComponents() {
             throw new Error('Components not initialized');
         }
 
-        const { IfcLoader, FragmentsManager, IfcPropertiesManager } = await import('@thatopen/components');
+        const { FragmentIfcLoader, FragmentsManager, IfcPropertiesManager } = await import('@thatopen/components');
         const { Highlighter, Outliner } = await import('@thatopen/components-front');
         const WEBIFC = await import('web-ifc');
 
-        fragmentIfcLoader = components.get(IfcLoader);
+        fragmentIfcLoader = components.get(FragmentIfcLoader);
         await fragmentIfcLoader.setup();
         fragmentIfcLoader.settings.webIfc.COORDINATE_TO_ORIGIN = true;
 
@@ -212,7 +212,7 @@ async function loadIfc() {
         const buffer = new Uint8Array(data);
         console.log('🧪 IFC file fetched, buffer size:', buffer.length);
 
-        model = await fragmentIfcLoader.load(buffer);
+        model = await fragmentIfcLoader.load(buffer, modelId);
 
         if (!model) throw new Error('Failed to load IFC model');
         model.name = modelId;


### PR DESCRIPTION
## Summary
- switch to `FragmentIfcLoader` so geometry can be exported directly from the browser
- pass model id when loading fragments
- update old viewer demo to use `FragmentIfcLoader`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6856af763974832ea40759167f3b8a2a