### PR TITLE
Add server-side fragment export

### DIFF
--- a/ifc_reuse/core/urls.py
+++ b/ifc_reuse/core/urls.py
@@ -21,4 +21,5 @@ urlpatterns = [
     path('add-comment/', views.add_comment, name='add_comment'),
     path('api/component-author/', views.get_component_author, name='get_component_author'),
     path('api/toggle-favorite/', views.toggle_favorite, name='toggle_favorite'),
+    path('save-fragment/', views.save_fragment, name='save_fragment'),
 ]

--- a/ifc_reuse/core/views.py
+++ b/ifc_reuse/core/views.py
@@ -268,3 +268,21 @@ def toggle_favorite(request):
         return JsonResponse({"error": "Component not found"}, status=404)
     except Exception as e:
         return JsonResponse({"error": str(e)}, status=500)
+
+
+@require_POST
+def save_fragment(request):
+    """Save uploaded fragment file to MEDIA_ROOT/fragments/{global_id}.frag"""
+    frag_file = request.FILES.get("fragment")
+    global_id = request.POST.get("global_id")
+
+    if not frag_file or not global_id:
+        return JsonResponse({"error": "fragment and global_id required"}, status=400)
+
+    fragments_dir = os.path.join(settings.MEDIA_ROOT, "fragments")
+    os.makedirs(fragments_dir, exist_ok=True)
+
+    file_path = os.path.join(fragments_dir, f"{global_id}.frag")
+    default_storage.save(file_path, frag_file)
+
+    return JsonResponse({"status": "saved", "path": os.path.join(settings.MEDIA_URL, "fragments", f"{global_id}.frag")})

--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -470,6 +470,20 @@ function setupSelection() {
                     console.warn('⚠️ fragments.exportFragments is not available. Skipping geometry export.');
                 }
 
+                if (fragData) {
+                    const formData = new FormData();
+                    formData.append('global_id', globalId || `frag_${expressID}`);
+                    formData.append('fragment', new Blob([fragData], { type: 'application/octet-stream' }), `${nameBase}.frag`);
+                    try {
+                        const resp = await fetch('/save-fragment/', { method: 'POST', body: formData });
+                        if (!resp.ok) {
+                            console.warn('⚠️ Failed to save fragment on server:', resp.statusText);
+                        }
+                    } catch (err) {
+                        console.error('❌ Error uploading fragment:', err);
+                    }
+                }
+
                 console.log('🗂️ Directory already selected:', dirHandle.name);
 
                 let globalId = metadata.GlobalId;


### PR DESCRIPTION
## Summary
- create endpoint `save_fragment` to store `.frag` uploads under `media/fragments/`
- wire new endpoint in `core/urls.py`
- upload fragment data from the viewer when saving components

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856b3e0236c832e811b4c2f07e63206