### PR TITLE
Fix fragment export and JSON storage

### DIFF
--- a/ifc_reuse/core/utils.py
+++ b/ifc_reuse/core/utils.py
@@ -114,8 +114,13 @@ def save_metadata_and_create_component(
     # 1. Save JSON metadata to disk
     base_path = "reusable_components"
     json_content = json.dumps(metadata, indent=2)
+    json_file = os.path.join(base_path, filename)
+
+    if default_storage.exists(json_file):
+        default_storage.delete(json_file)
+
     json_path = default_storage.save(
-        os.path.join(base_path, filename),
+        json_file,
         ContentFile(json_content.encode("utf-8")),
     )
 
@@ -149,19 +154,18 @@ def save_metadata_and_create_component(
 
     # 6. Save to database if everything is in place
     if upload:
-            materials = metadata.get("materials")
-            if isinstance(materials, list) and materials:
-                material = materials[0].get("name", "xxx")
-            else:
-                material = "xxx"
-            ReusableComponent.objects.create(
-            ifc_file = upload,
-            component_type = metadata.get("type", "Unknown"),
-            storey = info.get("storey"),
-            material_name = material,
-            json_file_path = json_path,
-            global_id = global_id,
-    )
-        
+        materials = metadata.get("materials")
+        if isinstance(materials, list) and materials:
+            material = materials[0].get("name", "xxx")
+        else:
+            material = "xxx"
+        ReusableComponent.objects.create(
+            ifc_file=upload,
+            component_type=metadata.get("type", "Unknown"),
+            storey=info.get("storey"),
+            material_name=material,
+            json_file_path=json_path,
+            global_id=global_id,
+        )
 
     return json_path

--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -372,14 +372,6 @@ function setupSelection() {
         saveButton.onclick = async () => {
             console.log('🟩 Button clicked');
 
-            let dirHandle;
-            try {
-                dirHandle = await window.showDirectoryPicker();
-            } catch (err) {
-                console.error('❌ User cancelled directory selection or failed:', err);
-                return;
-            }
-
             if (!lastSelected) {
                 console.warn('⚠️ No selection found');
                 return;
@@ -446,6 +438,12 @@ function setupSelection() {
 
                 console.log('🧠 Properties:', metadata);
 
+                let globalId = metadata.GlobalId;
+                if (globalId && typeof globalId === 'object') {
+                    globalId = globalId.value || globalId.id || globalId.GlobalId || globalId.toString();
+                }
+                const nameBase = globalId || `frag_${expressID}`;
+
                 try {
                     const resp = await fetch(`/get-element-info/?model_id=${encodeURIComponent(currentModelId)}&express_id=${expressID}`);
                     if (resp.ok) {
@@ -483,19 +481,6 @@ function setupSelection() {
                         console.error('❌ Error uploading fragment:', err);
                     }
                 }
-
-                console.log('🗂️ Directory already selected:', dirHandle.name);
-
-                let globalId = metadata.GlobalId;
-                if (globalId && typeof globalId === 'object') {
-                    globalId = globalId.value || globalId.id || globalId.GlobalId || globalId.toString();
-                }
-                const nameBase = globalId || `frag_${expressID}`;
-                const jsonFileHandle = await dirHandle.getFileHandle(`${nameBase}.json`, { create: true });
-                const jsonWritable = await jsonFileHandle.createWritable();
-                await jsonWritable.write(JSON.stringify(metadata, null, 2));
-                await jsonWritable.close();
-                console.log('✅ Metadata saved:', `${nameBase}.json`);
 
                 const jsonFilePath = `reusable_components/${nameBase}.json`;
                 console.log('📤 Sending json_file_path to backend:', jsonFilePath);


### PR DESCRIPTION
## Summary
- remove manual directory picker and export fragments directly to backend
- ensure metadata JSON overwrites existing files

## Testing
- `python ifc_reuse/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6856b5bd2b64832ea43ca800246ad6a1