### PR TITLE
Add element extraction workflow

### DIFF
--- a/ifc_reuse/frontend/extractor.js
+++ b/ifc_reuse/frontend/extractor.js
@@ -1,0 +1,34 @@
+// Utility for extracting IFC geometry of a single element
+// using web-ifc-viewer. This runs in parallel to the main
+// viewer which uses ThatOpen IfcLoader.
+import { IfcViewerAPI } from 'web-ifc-viewer';
+import { FragmentsManager } from '@thatopen/fragments';
+
+// Export fragment data (binary) for a specific express ID
+export async function extractExpressID(url, expressID) {
+    // Hidden container so viewer initialisation does not touch main canvas
+    const hidden = document.createElement('div');
+    hidden.style.display = 'none';
+    document.body.appendChild(hidden);
+
+    const viewer = new IfcViewerAPI({ container: hidden });
+    await viewer.IFC.setWasmPath('/static/');
+
+    const model = await viewer.IFC.loadIfcUrl(url);
+    const subset = viewer.IFC.loader.ifcManager.createSubset({
+        modelID: model.modelID,
+        ids: [expressID],
+        removePrevious: true,
+    });
+
+    const fragments = new FragmentsManager();
+    const group = fragments.newFragmentsGroup();
+    fragments.addMeshToGroup(subset, group);
+
+    const data = fragments.exportFragments(group);
+
+    viewer.IFC.loader.ifcManager.removeSubset(model.modelID, subset.material, subset.geometry);
+    viewer.dispose();
+    hidden.remove();
+    return data;
+}

--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import * as BUI from '@thatopen/ui';
+import { extractExpressID } from './extractor.js';
 
 // Global variables
 let components = null;
@@ -12,6 +13,8 @@ let outliner = null;
 let model = null;
 let modelGroupUUID = null;
 let currentModelId = null;
+let currentModelUrl = null;
+let currentModelBuffer = null;
 let lastSelected = null;
 let saveButton = null;
 let container = null;
@@ -205,11 +208,13 @@ async function loadIfc() {
         const file = files.find(f => String(f.id) === String(modelId));
         if (!file) throw new Error(`No IFC file found for model_id: ${modelId}`);
         console.log('🧪 Found IFC file:', file.url);
+        currentModelUrl = file.url;
 
         const res = await fetch(file.url);
         if (!res.ok) throw new Error(`HTTP error ${res.status}: ${res.statusText}`);
         const data = await res.arrayBuffer();
         const buffer = new Uint8Array(data);
+        currentModelBuffer = buffer;
         console.log('🧪 IFC file fetched, buffer size:', buffer.length);
 
         model = await fragmentIfcLoader.load(buffer);
@@ -460,11 +465,18 @@ function setupSelection() {
                 }
 
                 let fragData = null;
-                if (typeof fragments.exportFragments === 'function') {
+                if (currentModelUrl) {
+                    try {
+                        fragData = await extractExpressID(currentModelUrl, expressID);
+                    } catch (err) {
+                        console.warn('⚠️ Extraction module failed:', err);
+                    }
+                }
+                if (!fragData && typeof fragments.exportFragments === 'function') {
                     console.log('🧪 Exporting fragment data for group:', fragmentID);
                     fragData = fragments.exportFragments(group);
                     if (!fragData) console.warn('⚠️ Failed to export fragment data for fragmentID:', fragmentID);
-                } else {
+                } else if (!fragData) {
                     console.warn('⚠️ fragments.exportFragments is not available. Skipping geometry export.');
                 }
 

--- a/ifc_reuse/frontend/package-lock.json
+++ b/ifc_reuse/frontend/package-lock.json
@@ -15,7 +15,8 @@
         "@thatopen/ui": "^2.4.5",
         "three": "^0.175.0",
         "three-mesh-bvh": "^0.9.0",
-        "web-ifc": "0.0.68"
+        "web-ifc": "0.0.68",
+        "web-ifc-viewer": "^0.0.66"
       },
       "devDependencies": {
         "vite": "^5.0.0"

--- a/ifc_reuse/frontend/package.json
+++ b/ifc_reuse/frontend/package.json
@@ -19,7 +19,8 @@
     "@thatopen/ui": "^2.4.5",
     "three": "^0.175.0",
     "three-mesh-bvh": "^0.9.0",
-    "web-ifc": "0.0.68"
+    "web-ifc": "0.0.68",
+    "web-ifc-viewer": "^0.0.66"
   },
   "devDependencies": {
     "vite": "^5.0.0"


### PR DESCRIPTION
## Summary
- add new extractor module to export geometry of a single IFC element
- store model URL/buffer when loading IFC
- use extractor on selection before exporting fragments
- add `web-ifc-viewer` dependency

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6856b82776c8832eb469ee19007cb503