### PR TITLE
Add component extraction endpoint

### DIFF
--- a/ifc_reuse/core/tests.py
+++ b/ifc_reuse/core/tests.py
@@ -1,3 +1,25 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
 
-# Create your tests here.
+from .models import UploadedIFC
+
+class ExtractComponentViewTests(TestCase):
+    def setUp(self):
+        try:
+            import ifcopenshell # noqa: F401
+        except Exception:
+            self.skipTest("ifcopenshell not installed")
+        self.client = Client()
+        self.upload = UploadedIFC.objects.create(
+            name="test.ifc",
+            file=SimpleUploadedFile("test.ifc", b"IFC"),
+        )
+
+    def test_missing_parameters(self):
+        response = self.client.post(
+            reverse('core:extract_component'),
+            data={},
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400)

--- a/ifc_reuse/core/urls.py
+++ b/ifc_reuse/core/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     path('api/component-author/', views.get_component_author, name='get_component_author'),
     path('api/toggle-favorite/', views.toggle_favorite, name='toggle_favorite'),
     path('save-fragment/', views.save_fragment, name='save_fragment'),
+    path('extract-component/', views.extract_component, name='extract_component'),
 ]


### PR DESCRIPTION
## Summary
- implement component extraction utilities
- add `/extract-component/` API endpoint and URL
- cover endpoint with a basic test

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6857c41966f0832ea33129115311b374