### PR TITLE
Fix globalId reference before initialization

### DIFF
--- a/ifc_reuse/frontend/main.js
+++ b/ifc_reuse/frontend/main.js
@@ -436,6 +436,11 @@ function setupSelection() {
                     materials: props.materials || props.Materials || null,
                 };
 
+                let globalId = metadata.GlobalId;
+                if (globalId && typeof globalId === 'object') {
+                    globalId = globalId.value || globalId.id || globalId.GlobalId || globalId.toString();
+                }
+
                 console.log('🧠 Properties:', metadata);
                 const extractionPayload = {
                     model_id: currentModelId,
@@ -464,10 +469,6 @@ function setupSelection() {
                     console.error('❌ Network error during extraction:', err);
                 }
 
-                let globalId = metadata.GlobalId;
-                if (globalId && typeof globalId === 'object') {
-                    globalId = globalId.value || globalId.id || globalId.GlobalId || globalId.toString();
-                }
                 const nameBase = globalId || `frag_${expressID}`;
 
                 try {


### PR DESCRIPTION
## Summary
- fix initialization order of `globalId` in the frontend selection saving logic

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test` *(fails: Missing script "test" & npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857cd4f8270832e973a7e7b59edeacf