### PR TITLE
Enable OBJ+MTL viewer in catalog

### DIFF
--- a/ifc_reuse/core/templates/reuse/catalog.html
+++ b/ifc_reuse/core/templates/reuse/catalog.html
@@ -8,6 +8,11 @@
     <script src="https://cdn.tailwindcss.com"></script>
 
     <script src="https://unpkg.com/@heroicons/vue@2.0.13/dist/heroicons.js"></script>
+    <!-- Three.js and loaders -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r150/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.150.1/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.150.1/examples/js/loaders/MTLLoader.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.150.1/examples/js/loaders/OBJLoader.js"></script>
     <style>
         .dropdown-content {
             display: none;
@@ -474,72 +479,71 @@
 
         // === Fragment viewer setup ===
 
-        let viewerWorld = null;
-        let viewerModel = null;
-        let viewerTHREE = null;
+        let scene, camera, renderer, controls, currentModel = null;
 
-        async function initViewer() {
-            viewerTHREE = await import('https://cdn.skypack.dev/three@0.150.1');
-            const { OrbitControls } = await import('https://cdn.skypack.dev/three-stdlib/controls/OrbitControls.js');
-
+        function initViewer() {
             const container = document.getElementById('viewer-container');
+            scene = new THREE.Scene();
+            camera = new THREE.PerspectiveCamera(60, container.clientWidth / container.clientHeight, 0.1, 1000);
+            renderer = new THREE.WebGLRenderer({ antialias: true });
+            renderer.setSize(container.clientWidth, container.clientHeight);
+            container.innerHTML = "";
+            container.appendChild(renderer.domElement);
 
-            viewerWorld = {
-                scene: new viewerTHREE.Scene(),
-                camera: new viewerTHREE.PerspectiveCamera(60, container.clientWidth / container.clientHeight, 0.1, 1000),
-                renderer: new viewerTHREE.WebGLRenderer({ antialias: true })
-            };
+            const ambientLight = new THREE.AmbientLight(0xffffff, 0.8);
+            scene.add(ambientLight);
+            const directionalLight = new THREE.DirectionalLight(0xffffff, 0.5);
+            directionalLight.position.set(5, 5, 5);
+            scene.add(directionalLight);
 
-            const ambientLight = new viewerTHREE.AmbientLight(0xffffff, 1);
-            viewerWorld.scene.add(ambientLight);
+            controls = new THREE.OrbitControls(camera, renderer.domElement);
+            camera.position.set(3, 3, 3);
+            controls.update();
 
-            const directionalLight = new viewerTHREE.DirectionalLight(0xffffff, 1);
-            directionalLight.position.set(10, 10, 10);
-            viewerWorld.scene.add(directionalLight);
-
-            viewerWorld.renderer.setSize(container.clientWidth, container.clientHeight);
-            container.appendChild(viewerWorld.renderer.domElement);
-            viewerWorld.camera.position.set(3, 3, 3);
-            viewerWorld.controls = new OrbitControls(viewerWorld.camera, viewerWorld.renderer.domElement);
-
-            const animate = () => {
-                requestAnimationFrame(animate);
-                viewerWorld.controls.update();
-                viewerWorld.renderer.render(viewerWorld.scene, viewerWorld.camera);
-            };
             animate();
         }
 
+        function animate() {
+            requestAnimationFrame(animate);
+            controls.update();
+            renderer.render(scene, camera);
+        }
 
-        async function loadOBJModel(objUrl, mtlUrl) {
-            if (!viewerWorld) return;
+        function loadOBJModel(globalId) {
+            const objPath = `/media/fragments/${globalId}.obj`;
+            const mtlPath = `/media/fragments/${globalId}.mtl`;
 
-            if (viewerModel) {
-                viewerWorld.scene.remove(viewerModel);
-            }
-
-            const THREE = viewerTHREE || await import('https://cdn.skypack.dev/three@0.150.1');
-            const { MTLLoader } = await import('https://cdn.skypack.dev/three-stdlib/loaders/MTLLoader.js');
-            const { OBJLoader } = await import('https://cdn.skypack.dev/three-stdlib/loaders/OBJLoader.js');
-
-            const mtlLoader = new MTLLoader();
-            mtlLoader.load(mtlUrl, (materials) => {
+            const mtlLoader = new THREE.MTLLoader();
+            mtlLoader.setPath(`/media/fragments/`);
+            mtlLoader.load(`${globalId}.mtl`, (materials) => {
                 materials.preload();
-                const objLoader = new OBJLoader();
+
+                const objLoader = new THREE.OBJLoader();
                 objLoader.setMaterials(materials);
-                objLoader.load(objUrl, (obj) => {
-                    viewerModel = obj;
-                    viewerWorld.scene.add(obj);
-                    const box = new THREE.Box3().setFromObject(obj);
-                    const size = box.getSize(new THREE.Vector3()).length();
+                objLoader.setPath(`/media/fragments/`);
+                objLoader.load(`${globalId}.obj`, (object) => {
+                    if (currentModel) {
+                        scene.remove(currentModel);
+                    }
+                    currentModel = object;
+                    scene.add(object);
+
+                    const box = new THREE.Box3().setFromObject(object);
                     const center = box.getCenter(new THREE.Vector3());
-                    viewerWorld.controls.target.copy(center);
-                    viewerWorld.camera.position.copy(center).add(new THREE.Vector3(size, size, size));
-                    viewerWorld.camera.near = size / 100;
-                    viewerWorld.camera.far = size * 100;
-                    viewerWorld.camera.updateProjectionMatrix();
-                    viewerWorld.controls.update();
+                    const size = box.getSize(new THREE.Vector3());
+                    const maxDim = Math.max(size.x, size.y, size.z);
+                    const scale = 2 / maxDim;
+                    object.scale.set(scale, scale, scale);
+                    object.position.sub(center.multiplyScalar(scale));
+
+                    camera.position.set(3, 3, 3);
+                    controls.target.set(0, 0, 0);
+                    controls.update();
+                }, undefined, (err) => {
+                    console.error('OBJ load error:', err);
                 });
+            }, undefined, (err) => {
+                console.error('MTL load error:', err);
             });
         }
 
@@ -786,14 +790,8 @@
 
                     await loadComments(globalId);
 
-                    const objPath = `/media/fragments/${globalId}.obj`;
-                    const mtlPath = `/media/fragments/${globalId}.mtl`;
-
                     try {
-                        if (!viewerWorld) {
-                            await initViewer();
-                        }
-                        await loadOBJModel(objPath, mtlPath);
+                        loadOBJModel(globalId);
                     } catch (err) {
                         console.error('Error loading OBJ/MTL files:', err);
                     }
@@ -849,6 +847,10 @@
             } catch (error) {
                 console.error('Error checking comments:', error);
             }
+        });
+
+        document.addEventListener('DOMContentLoaded', () => {
+            initViewer();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- load Three.js and loader scripts via CDN
- replace dynamic viewer with global OBJ+MTL viewer
- initialise viewer on DOMContentLoaded

## Testing
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6857e420b628832e9ac04a3907c6d919