### PR TITLE
Fix catalog component info display

### DIFF
--- a/ifc_reuse/core/templates/reuse/catalog.html
+++ b/ifc_reuse/core/templates/reuse/catalog.html
@@ -361,6 +361,8 @@
                             data-json-path="{% static comp.global_id|add:'.json' %}"
                             data-name="{{ comp.name }}"
                             data-global-id="{{ comp.global_id }}"
+                            data-project-name="{{ comp.project_name }}"
+                            data-uploaded="{{ comp.uploaded_at|date:'d.m.Y' }}"
                             data-has-comments="false"
                             data-is-favorite="{% if comp.global_id in favorite_global_ids %}true{% else %}false{% endif %}">
                             <span class="flex-grow">{{ comp.name }} ({{ comp.global_id }})</span>

--- a/ifc_reuse/core/views.py
+++ b/ifc_reuse/core/views.py
@@ -31,7 +31,9 @@ def categories(request):
         cat = component.component_type or 'Unknown'
         info = {
             'name': component.material_name or 'Unnamed',
-            'global_id': component.global_id or component.json_file_path.split('/')[-1].replace('.json', '')
+            'global_id': component.global_id or component.json_file_path.split('/')[-1].replace('.json', ''),
+            'project_name': component.ifc_file.project_name,
+            'uploaded_at': component.uploaded_at,
         }
         categories.setdefault(cat, []).append(info)
 

--- a/ifc_reuse/static/js/catalog-viewer.js
+++ b/ifc_reuse/static/js/catalog-viewer.js
@@ -282,15 +282,12 @@
                     globalIdEl.classList.toggle('na', !(data.GlobalId?.value || globalId));
 
                     const projectEl = document.getElementById('element-project');
-                    {% for comp in components %}
-                        {% if comp.global_id == globalId %}
-                            projectEl.textContent = '{{ comp.ifc_file.project_name|default:"N/A" }}';
-                            projectEl.classList.toggle('na', !'{{ comp.ifc_file.project_name }}');
+                    projectEl.textContent = item.dataset.projectName || 'N/A';
+                    projectEl.classList.toggle('na', !item.dataset.projectName);
+
                     const uploadedEl = document.getElementById('element-uploaded');
-                    uploadedEl.textContent = '{{ comp.uploaded_at|date:"d.m.Y" }}' || 'N/A';
-                    uploadedEl.classList.toggle('na', !'{{ comp.uploaded_at }}');
-                        {% endif %}
-                    {% endfor %}
+                    uploadedEl.textContent = item.dataset.uploaded || 'N/A';
+                    uploadedEl.classList.toggle('na', !item.dataset.uploaded);
 
                     document.getElementById('element-name').textContent = data.Name?.value || name || 'N/A';
 


### PR DESCRIPTION
## Summary
- include project name and upload date in catalog view
- expose those fields as data attributes in the catalog template
- use the new attributes in `catalog-viewer.js`

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6857e8729994832e8949b81926cf444c