### PR TITLE
Fix three.js loader usage

### DIFF
--- a/ifc_reuse/frontend/catalog-viewer.js
+++ b/ifc_reuse/frontend/catalog-viewer.js
@@ -21,7 +21,7 @@ function initViewer() {
     directionalLight.position.set(5, 5, 5);
     scene.add(directionalLight);
 
-    controls = new THREE.OrbitControls(camera, renderer.domElement);
+    controls = new OrbitControls(camera, renderer.domElement);
     camera.position.set(3, 3, 3);
     controls.update();
 
@@ -35,12 +35,12 @@ function animate() {
 }
 
 function loadOBJModel(globalId) {
-    const mtlLoader = new THREE.MTLLoader();
+    const mtlLoader = new MTLLoader();
     mtlLoader.setPath('/media/fragments/');
     mtlLoader.load(`${globalId}.mtl`, (materials) => {
         materials.preload();
 
-        const objLoader = new THREE.OBJLoader();
+        const objLoader = new OBJLoader();
         objLoader.setMaterials(materials);
         objLoader.setPath('/media/fragments/');
         objLoader.load(`${globalId}.obj`, (object) => {


### PR DESCRIPTION
## Summary
- fix initialization of Three.js loaders and controls

## Testing
- `python ifc_reuse/manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6857ffbd7c80832ebbf343b6bf4accf6