### PR TITLE
Fix Tkinter runtime errors in thumbnail generation

### DIFF
--- a/ifc_reuse/core/obj.py
+++ b/ifc_reuse/core/obj.py
@@ -1,4 +1,6 @@
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from scipy.spatial import ConvexHull
 


### PR DESCRIPTION
## Summary
- use a non-GUI Matplotlib backend when generating thumbnails

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859646f7d68832e9a5791c111d35fd3