### PR TITLE
Fix missing metadata container

### DIFF
--- a/ifc_reuse/core/templates/reuse/catalog.html
+++ b/ifc_reuse/core/templates/reuse/catalog.html
@@ -418,6 +418,9 @@
                     <a id="pdf-download-link" href="#" target="_blank" class="text-[#4CAF50] hover:underline ml-2">Download</a>
                 </div>
 
+                <!-- Container for additional metadata populated by JavaScript -->
+                <div id="element-other-data"></div>
+
                 <!-- Sección de comentarios -->
                 <div class="comments-section">
                     <h4>Kommentare</h4>


### PR DESCRIPTION
## Summary
- add missing `element-other-data` div in catalog details panel

## Testing
- `python3 manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685970340d38832ea8388c3b493fe8f1