### PR TITLE
Fix catalog filter with case-insensitive query

### DIFF
--- a/ifc_reuse/core/views.py
+++ b/ifc_reuse/core/views.py
@@ -27,7 +27,8 @@ def catalog(request):
 
 def categories(request):
     components_qs = ReusableComponent.objects.select_related('ifc_file').all()
-    available_categories = (
+    # Evaluate to a list immediately to avoid unexpected lazy evaluation later
+    available_categories = list(
         ReusableComponent.objects.order_by('component_type')
         .values_list('component_type', flat=True)
         .distinct()
@@ -35,7 +36,8 @@ def categories(request):
 
     selected_category = request.GET.get('category')
     if selected_category:
-        components_qs = components_qs.filter(component_type=selected_category)
+        # use case-insensitive match to avoid issues with capitalization in the database
+        components_qs = components_qs.filter(component_type__iexact=selected_category)
 
     categories = {}
     for component in components_qs:


### PR DESCRIPTION
## Summary
- make category filter case-insensitive
- ensure available categories evaluated immediately

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python ifc_reuse/manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685a88664d38832eb808c776e1e56960