### PR TITLE
Fix catalog panel close and hide unused fields

### DIFF
--- a/ifc_reuse/core/templates/reuse/catalog.html
+++ b/ifc_reuse/core/templates/reuse/catalog.html
@@ -450,13 +450,13 @@
                 <div class="property">
                     <strong>Typ:</strong> <span id="element-type" class="na">N/A</span>
                 </div>
-                <div class="property">
+                <div class="property hidden">
                     <strong>Maße:</strong> <span id="element-dimensions" class="na">N/A</span>
                 </div>
                 <div class="property">
                     <strong>Material:</strong> <span id="element-material" class="na">N/A</span>
                 </div>
-                <div class="property">
+                <div class="property hidden">
                     <strong>Gewicht:</strong> <span id="element-weight" class="na">N/A</span>
                 </div>
                 <div class="property">
@@ -545,6 +545,22 @@
     </script>
 
     <script src="{% static 'frontend/catalog-viewer.iife.js' %}?v={{ BUILD_TIMESTAMP }}"></script>
+
+    <script>
+        function closeDetailsPanel() {
+            document.getElementById('details-panel').classList.remove('show');
+            document.querySelectorAll('.component-item').forEach(item => item.classList.remove('selected'));
+        }
+
+        document.addEventListener('click', (e) => {
+            if (e.target && e.target.id === 'author-profile-button') {
+                const href = e.target.getAttribute('href');
+                if (href && href !== '#') {
+                    window.location.href = href;
+                }
+            }
+        });
+    </script>
 
     <script>
         async function generatePassport(globalId, modelId) {


### PR DESCRIPTION
## Summary
- hide weight and dimensions fields in catalog detail panel
- add script for closing detail panel
- ensure author profile button opens link

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685bcbb304c8832ead7b86206d87b721