### PR TITLE
Show project location in catalog details

### DIFF
--- a/ifc_reuse/core/templates/reuse/catalog.html
+++ b/ifc_reuse/core/templates/reuse/catalog.html
@@ -417,6 +417,7 @@
                             data-global-id="{{ comp.global_id }}"
                             data-model-id="{{ comp.model_id }}"
                             data-project-name="{{ comp.project_name }}"
+                            data-location="{{ comp.location }}"
                             data-uploaded="{{ comp.uploaded_at|date:'d.m.Y' }}"
                             data-has-comments="false"
                             data-is-favorite="{% if comp.global_id in favorite_global_ids %}true{% else %}false{% endif %}">
@@ -467,6 +468,9 @@
                 </div>
                 <div class="property">
                     <strong>Projekt:</strong> <span id="element-project" class="na">N/A</span>
+                </div>
+                <div class="property">
+                    <strong>Standort:</strong> <span id="element-location" class="na">N/A</span>
                 </div>
                 <div class="property">
                     <strong>Hochgeladen:</strong> <span id="element-uploaded" class="na">N/A</span>

--- a/ifc_reuse/core/views.py
+++ b/ifc_reuse/core/views.py
@@ -76,6 +76,7 @@ def categories(request):
             'project_name': component.ifc_file.project_name,
             'uploaded_at': component.uploaded_at,
             'model_id': component.ifc_file_id,
+            'location': component.ifc_file.location,
         }
         categories.setdefault(cat, []).append(info)
 
@@ -108,6 +109,7 @@ def catalog_api(request):
             'project_name': component.ifc_file.project_name,
             'uploaded_at': component.uploaded_at,
             'model_id': component.ifc_file_id,
+            'location': component.ifc_file.location,
         }
 
         categories.setdefault(cat, []).append(info)

--- a/ifc_reuse/frontend/catalog-viewer.js
+++ b/ifc_reuse/frontend/catalog-viewer.js
@@ -343,6 +343,10 @@ document.querySelectorAll('.component-item').forEach(item => {
             projectEl.textContent = item.dataset.projectName || 'N/A';
             projectEl.classList.toggle('na', !item.dataset.projectName);
 
+            const locationEl = document.getElementById('element-location');
+            locationEl.textContent = item.dataset.location || 'N/A';
+            locationEl.classList.toggle('na', !item.dataset.location);
+
             const uploadedEl = document.getElementById('element-uploaded');
             uploadedEl.textContent = item.dataset.uploaded || 'N/A';
             uploadedEl.classList.toggle('na', !item.dataset.uploaded);


### PR DESCRIPTION
## Summary
- include project location in the component context data
- pass the location as dataset attribute and show it in the details panel
- display the location in the JS panel logic

## Testing
- `python -m pytest -q`
- `python ifc_reuse/manage.py check` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bcf56c914832ea0fec6b58c463f0b